### PR TITLE
added check for 2 arguments in command 'inventory'

### DIFF
--- a/src/main/java/org/csanchez/aws/glacier/Glacier.java
+++ b/src/main/java/org/csanchez/aws/glacier/Glacier.java
@@ -110,6 +110,10 @@ public class Glacier {
         Glacier glacier = new Glacier(credentials, cmd.getOptionValue("region", "us-east-1"));
 
         if ("inventory".equals(arguments.get(0))) {
+            if (arguments.size() != 2) {
+                printHelp(options);
+                return;
+            }
             glacier.inventory(arguments.get(1), cmd.getOptionValue("topic", "glacier"), cmd.getOptionValue("queue", "glacier"),
                     cmd.getOptionValue("file", "glacier.json"));
         } else if ("upload".equals(arguments.get(0))) {


### PR DESCRIPTION
Issuing the command 'inventory' requires two arguments: 'inventory' followed by the vault name.  There was not a check in place for this, though there is a check at the top of the main method to verify that the args array has at least 2 elements.  However, the args array can include command line switches such as "-region" so commands like the following pass that check and go on to cause an exception...

```
$ java -jar glacier-1.0-jar-with-dependencies.jar -region us-west-2 inventory
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 1
    at java.util.Arrays$ArrayList.get(Arrays.java:3381)
    at org.csanchez.aws.glacier.Glacier.main(Glacier.java:113)
```

The check that I added fixes this problem and prints the help text as expected. 
