### PR TITLE
Updated AWS Java SDK version; minor refactor of props File object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.3.17</version>
+      <version>1.3.21</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/src/main/java/org/csanchez/aws/glacier/Glacier.java
+++ b/src/main/java/org/csanchez/aws/glacier/Glacier.java
@@ -95,8 +95,7 @@ public class Glacier {
             return;
         }
 
-        String userHome = System.getProperty("user.home");
-        File props = new File(userHome + "/AwsCredentials.properties");
+        File props = new File(System.getProperty("user.home") + "/AwsCredentials.properties");
         if (!props.exists()) {
             System.out.println("Missing " + props.getAbsolutePath());
             return;
@@ -106,7 +105,7 @@ public class Glacier {
         CommandLine cmd = parser.parse(options, args);
         List<String> arguments = Arrays.asList(cmd.getArgs());
 
-        AWSCredentials credentials = new PropertiesCredentials(new File(userHome + "/AwsCredentials.properties"));
+        AWSCredentials credentials = new PropertiesCredentials(props);
         Glacier glacier = new Glacier(credentials, cmd.getOptionValue("region", "us-east-1"));
 
         if ("inventory".equals(arguments.get(0))) {


### PR DESCRIPTION
Updated to latest version of AWS Java SDK (v1.3.21) available at this time.  There have been a handful of changes relevant to Glacier since v1.3.17.  Details here...

http://aws.amazon.com/releasenotes

Also made a minor change to use the existing props File object in the instantiation of the AWSCredentials object instead of newing up an identical File object.
