### PR TITLE
fixed issue #10 regarding archive IDs that start with a dash

### DIFF
--- a/src/main/java/org/csanchez/aws/glacier/Glacier.java
+++ b/src/main/java/org/csanchez/aws/glacier/Glacier.java
@@ -135,14 +135,14 @@ public class Glacier {
                     if (arguments.size() != 4) {
                         throw new GlacierCliException("The download command requires exactly four parameters.");
                     }
-                    glacier.download(arguments.get(1), arguments.get(2), arguments.get(3));
+                    glacier.download(arguments.get(1), arguments.get(2).replace("\\", ""), arguments.get(3));
                     break;
 
                 case DELETE:
                     if (arguments.size() != 3) {
                         throw new GlacierCliException("The delete command requires exactly three parameters.");
                     }
-                    glacier.delete(arguments.get(1), arguments.get(2));
+                    glacier.delete(arguments.get(1), arguments.get(2).replace("\\", ""));
                     break;
             }
         } catch (GlacierCliException e) {


### PR DESCRIPTION
Called .replace() on the archive ID arguments to remove the backslashes that were used to escape the dash at the beginning of the archive ID.
