### PR TITLE
Add sns and sqs for downloading

### DIFF
--- a/src/main/java/org/csanchez/aws/glacier/Glacier.java
+++ b/src/main/java/org/csanchez/aws/glacier/Glacier.java
@@ -196,8 +196,13 @@ public class Glacier {
         String msg = "Downloading " + archiveId + " from Glacier vault " + vaultName;
         System.out.println(msg);
 
+	sqsClient = new AmazonSQSClient(credentials);
+        sqsClient.setEndpoint("https://sqs." + region + ".amazonaws.com");
+        snsClient = new AmazonSNSClient(credentials);
+        snsClient.setEndpoint("https://sns." + region + ".amazonaws.com");
+
         try {
-            ArchiveTransferManager atm = new ArchiveTransferManager(client, credentials);
+            ArchiveTransferManager atm = new ArchiveTransferManager(client, sqsClient,snsClient);
             atm.download(vaultName, archiveId, new File(downloadFilePath));
         } catch (Exception e) {
             throw new RuntimeException("Error " + msg, e);


### PR DESCRIPTION
Hi,
For download from other region than us-east-1, need to specified a custom sns and sqs at your atm instance.
https://forums.aws.amazon.com/message.jspa?messageID=374602#374602

without sqs and sns custom region , have this error : 
 Caused by: Status Code: 400, AWS Service: AmazonGlacier, AWS Request ID:  9HzSRRQBNd_zaZRNXEolipZmuUsrH5MNPT4KrJNtX6WDhw4, AWS Error Code: InvalidParameterValueException, AWS Error Message: SNS topics must be in the local AWS region: arn:aws:sns:us-east-1:xxxxx:glacier-archive-transfer-xxxxx"

Now that's working
