### PR TITLE
Indicate error with exit code

### DIFF
--- a/src/main/java/org/csanchez/aws/glacier/Glacier.java
+++ b/src/main/java/org/csanchez/aws/glacier/Glacier.java
@@ -97,7 +97,7 @@ public class Glacier {
         File props = new File(System.getProperty("user.home") + "/AwsCredentials.properties");
         if (!props.exists()) {
             System.out.println("Missing " + props.getAbsolutePath());
-            return;
+            System.exit(1);
         }
 
         Options options = commonOptions();
@@ -186,6 +186,7 @@ public class Glacier {
                                            + "list vault_name |"
                                            + "info vault_name |"
                                            + "inventory vault_name", options);
+            System.exit(1);
         }
     }
 


### PR DESCRIPTION
This way, errors can be caught when using glacier-cli from a shell script
or command line.
