### PR TITLE
Create vault and use a single Java style

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A command line client to [Amazon Glacier](http://aws.amazon.com/glacier) based on AWS examples.
 
+
 ## Configuration
 
 Create `$HOME/AwsCredentials.properties` with your AWS keys
@@ -12,15 +13,22 @@ accessKey=…
 
 ```
 
+
 ## Commands
 
+### Work with archives
+
 * `upload vault_name file1 file2 …`
-* `download vault_name archiveId output_file`
 * `delete vault_name archiveId`
+* `download vault_name archiveId output_file`
+
+### Work with vaults
+
+* `create-vault vault_name`
+* `delete-vault vault_name`
 * `inventory vault_name`
-* `list`
 * `info vault_name`
-* `remove vault_name`
+* `list`
 
 
 ## Command line options
@@ -36,44 +44,40 @@ accessKey=…
 
 ## Examples
 
-Upload file1 and file2 to vault `pictures`
+### Work with archives
 
+#### Upload file1 and file2 to vault `pictures`
 `java -jar glacier-1.0-jar-with-dependencies.jar upload pictures file1 file2`
 
-Download archive with id xxx from vault `pictures` to file `pic.tar` (takes >4 hours)
-
-`java -jar glacier-1.0-jar-with-dependencies.jar download pictures xxx pic.tar`
-
-Delete archive with id xxx from vault `pictures`
-
+#### Delete archive with id xxx from vault `pictures`
 `java -jar glacier-1.0-jar-with-dependencies.jar delete pictures xxx`
 
-Get the inventory for vault `pictures` (takes >4 hours)
+#### Download archive with id xxx from vault `pictures` to file `pic.tar` (takes >4 hours)
+`java -jar glacier-1.0-jar-with-dependencies.jar download pictures xxx pic.tar`
 
+
+### Work with vaults
+
+### Create vault
+`java -jar glacier-1.0-jar-with-dependencies.jar create-vault avault`
+
+#### Delete vault in Europe region
+`java -jar glacier-1.0-jar-with-dependencies.jar -region eu-west-1 delete-vault mypreciousvault`
+
+#### Get the inventory for vault `pictures` (takes >4 hours)
 `java -jar glacier-1.0-jar-with-dependencies.jar inventory pictures`
 
-Upload file1 and file2 to vault `pictures` in Europe region
-
-`java -jar glacier-1.0-jar-with-dependencies.jar -region eu-west-1 upload pictures file1 file2`
-
-Remove vault in Europe region
-
-`java -jar glacier-1.0-jar-with-dependencies.jar -region eu-west-1 remove mypreciousvault`
-
-List vaults
-
-`java -jar glacier-1.0-jar-with-dependencies.jar list`
-
-get vault info
-
+#### Get vault info
 `java -jar glacier-1.0-jar-with-dependencies.jar info pictures`
 
-
+#### List vaults
+`java -jar glacier-1.0-jar-with-dependencies.jar list`
 
 
 ## Building
 
 `mvn clean package`
+
 
 ## More info
 
@@ -81,8 +85,8 @@ Uses Glacier high level API for uploading, downloading, deleting files, and the 
 
 More info at the [AWS Glacier development docs](http://docs.amazonwebservices.com/amazonglacier/latest/dev/).
 
-License
--------
+
+## License
 ```
   Copyright 2012 Carlos Sanchez
 
@@ -98,4 +102,3 @@ License
   See the License for the specific language governing permissions and
   limitations under the License.
 ```
-

--- a/src/main/java/org/csanchez/aws/glacier/Glacier.java
+++ b/src/main/java/org/csanchez/aws/glacier/Glacier.java
@@ -36,6 +36,7 @@ import com.amazonaws.auth.policy.Statement;
 import com.amazonaws.auth.policy.Statement.Effect;
 import com.amazonaws.auth.policy.actions.SQSActions;
 import com.amazonaws.services.glacier.AmazonGlacierClient;
+import com.amazonaws.services.glacier.model.CreateVaultRequest;
 import com.amazonaws.services.glacier.model.DeleteArchiveRequest;
 import com.amazonaws.services.glacier.model.GetJobOutputRequest;
 import com.amazonaws.services.glacier.model.GetJobOutputResult;
@@ -125,6 +126,7 @@ public class Glacier {
             Glacier glacier = new Glacier(credentials, cmd.getOptionValue("region", "us-east-1"));
 
             switch (command) {
+
                 case INVENTORY:
                     if (arguments.size() != 2) {
                         throw new GlacierCliException("The inventory command requires exactly two parameters.");
@@ -155,11 +157,11 @@ public class Glacier {
                     }
                     glacier.delete(arguments.get(1), arguments.get(2));
                     break;
-                case REMOVE:
+                case DELETE_VAULT:
                     if (arguments.size() != 2) {
-                        throw new GlacierCliException("The remove command requires exactly two parameters.");
+                        throw new GlacierCliException("The delete-vault command requires exactly two parameters.");
                     }
-                    glacier.remove(arguments.get(1));
+                    glacier.deleteVault(arguments.get(1));
                     break;
 
                 case INFO:
@@ -171,6 +173,13 @@ public class Glacier {
 
                 case LIST:
                     glacier.list();
+                    break;
+
+                case CREATE_VAULT:
+                    if (arguments.size() != 1) {
+                        throw new GlacierCliException("The create-vault command requires exactly one parameter.");
+                    }
+                    glacier.createVault(arguments.get(1));
                     break;
             }
         } catch (GlacierCliException e) {
@@ -192,10 +201,11 @@ public class Glacier {
                             "glacier " + "upload vault_name file1 file2 ... | "
                                        + "download vault_name archiveId output_file | "
                                        + "delete vault_name archiveId | "
-                                       + "remove vault_name | "
+                                       + "delete-vault vault_name | "
                                        + "list vault_name | "
                                        + "info vault_name | "
-                                       + "inventory vault_name",
+                                       + "inventory vault_name | "
+                                       + "create-vault vault_name",
                             null,
                             options,
                             formatter.getLeftPadding(),
@@ -309,7 +319,7 @@ public class Glacier {
         }
     }
 
-    public void remove (String vaultName) {
+    public void deleteVault (String vaultName) {
         String msg = "Deleting vault " + vaultName;
         System.out.println(msg);
 
@@ -338,6 +348,18 @@ public class Glacier {
                             + "\n\tLast inventory date : " + vault.getLastInventoryDate ());
             }
 
+        } catch (Exception e) {
+            throw new RuntimeException("Error " + msg, e);
+        }
+    }
+
+    public void createVault(String vaultName) {
+        String msg = "Creating vault \"" + vaultName + "\" ...";
+        System.out.println(msg);
+
+        try {
+            client.createVault(new CreateVaultRequest(vaultName));
+            System.out.println("Created vault: \"" + vaultName+ "\"");
         } catch (Exception e) {
             throw new RuntimeException("Error " + msg, e);
         }

--- a/src/main/java/org/csanchez/aws/glacier/Glacier.java
+++ b/src/main/java/org/csanchez/aws/glacier/Glacier.java
@@ -151,7 +151,6 @@ public class Glacier {
                     glacier.download(arguments.get(1), arguments.get(2), arguments.get(3));
                     break;
 
-
                 // Vault commands
                 case CREATE_VAULT:
                     if (arguments.size() != 1) {
@@ -288,7 +287,7 @@ public class Glacier {
         snsClient.setEndpoint("https://sns." + region + ".amazonaws.com");
 
         try {
-            ArchiveTransferManager atm = new ArchiveTransferManager(client, sqsClient,snsClient);
+            ArchiveTransferManager atm = new ArchiveTransferManager(client, sqsClient, snsClient);
             atm.download(vaultName, archiveId, new File(downloadFilePath));
         } catch (Exception e) {
             throw new RuntimeException("Error " + msg, e);
@@ -316,7 +315,7 @@ public class Glacier {
         System.out.println(msg);
 
         try {
-            client.deleteVault (new DeleteVaultRequest(vaultName));
+            client.deleteVault(new DeleteVaultRequest(vaultName));
             System.out.println("Deleted vault: " + vaultName);
         } catch (Exception e) {
             throw new RuntimeException("Error " + msg, e);
@@ -355,37 +354,37 @@ public class Glacier {
         }
     }
 
-    public void info (String vaultName) {
-        String msg = "Info " + vaultName +"...";
-        System.out.println (msg);
+    public void info(String vaultName) {
+        String msg = "Info " + vaultName + "...";
+        System.out.println(msg);
 
         try {
-            DescribeVaultResult vaultdescribe = client.describeVault (new DescribeVaultRequest (vaultName));
+            DescribeVaultResult vaultdescribe = client.describeVault(new DescribeVaultRequest(vaultName));
             System.out.println ("Vault : " + vaultName
-                            + "\n\tCreation date : " + vaultdescribe.getCreationDate ()
-                            + "\n\tNumber of archives : " + vaultdescribe.getNumberOfArchives ()
-                            + "\n\tVault size : " + vaultdescribe.getSizeInBytes ()
-                            + "\n\tLast inventory date : " + vaultdescribe.getLastInventoryDate ());
+                            + "\n\tCreation date : " + vaultdescribe.getCreationDate()
+                            + "\n\tNumber of archives : " + vaultdescribe.getNumberOfArchives()
+                            + "\n\tVault size : " + vaultdescribe.getSizeInBytes()
+                            + "\n\tLast inventory date : " + vaultdescribe.getLastInventoryDate());
         } catch (Exception e) {
             throw new RuntimeException("Error " + msg, e);
         }
     }
 
-    public void list () {
+    public void list() {
         String msg = "Listing ...";
-        System.out.println (msg);
+        System.out.println(msg);
 
         try {
-            ListVaultsResult vaults = client.listVaults (new ListVaultsRequest ());
+            ListVaultsResult vaults = client.listVaults(new ListVaultsRequest());
 
             for (DescribeVaultOutput vault: vaults.getVaultList())
             {
-                System.out.println ("----");
-                System.out.println ("Vault : " + vault.getVaultName()
-                            + "\n\tCreation date : " + vault.getCreationDate ()
-                            + "\n\tNumber of archives : " + vault.getNumberOfArchives ()
-                            + "\n\tVault size : " + vault.getSizeInBytes ()
-                            + "\n\tLast inventory date : " + vault.getLastInventoryDate ());
+                System.out.println("----");
+                System.out.println("Vault : " + vault.getVaultName()
+                            + "\n\tCreation date : " + vault.getCreationDate()
+                            + "\n\tNumber of archives : " + vault.getNumberOfArchives()
+                            + "\n\tVault size : " + vault.getSizeInBytes()
+                            + "\n\tLast inventory date : " + vault.getLastInventoryDate());
             }
 
         } catch (Exception e) {
@@ -414,6 +413,7 @@ public class Glacier {
         Map<String, String> queueAttributes = new HashMap<String, String>();
         queueAttributes.put("Policy", sqsPolicy.toJson());
         sqsClient.setQueueAttributes(new SetQueueAttributesRequest(config.sqsQueueURL, queueAttributes));
+
         return config;
     }
 
@@ -427,11 +427,11 @@ public class Glacier {
         SubscribeResult result2 = snsClient.subscribe(request2);
 
         config.snsSubscriptionARN = result2.getSubscriptionArn();
+
         return config;
     }
 
     private String initiateJobRequest(String vaultName, String snsTopicARN) {
-
         JobParameters jobParameters = new JobParameters().withType("inventory-retrieval").withSNSTopic(snsTopicARN);
 
         InitiateJobRequest request = new InitiateJobRequest().withVaultName(vaultName).withJobParameters(jobParameters);
@@ -442,7 +442,6 @@ public class Glacier {
     }
 
     private Boolean waitForJobToComplete(String jobId, String sqsQueueUrl) throws InterruptedException, JsonParseException, IOException {
-
         Boolean messageFound = false;
         Boolean jobSuccessful = false;
         ObjectMapper mapper = new ObjectMapper();
@@ -480,7 +479,6 @@ public class Glacier {
     }
 
     private void downloadJobOutput(String vaultName, String jobId, String fileName) throws IOException {
-
         GetJobOutputRequest getJobOutputRequest = new GetJobOutputRequest().withVaultName(vaultName).withJobId(jobId);
         GetJobOutputResult getJobOutputResult = client.getJobOutput(getJobOutputRequest);
 

--- a/src/main/java/org/csanchez/aws/glacier/GlacierCliCommand.java
+++ b/src/main/java/org/csanchez/aws/glacier/GlacierCliCommand.java
@@ -15,7 +15,8 @@ public enum GlacierCliCommand {
     DELETE("delete"),
     LIST("list"),
     INFO("info"),
-    REMOVE("remove");
+    DELETE_VAULT("delete-vault"),
+    CREATE_VAULT("create-vault");
 
     private static final Map<String, GlacierCliCommand> lookup
             = new HashMap<String, GlacierCliCommand>();

--- a/src/main/java/org/csanchez/aws/glacier/GlacierCliCommand.java
+++ b/src/main/java/org/csanchez/aws/glacier/GlacierCliCommand.java
@@ -9,14 +9,17 @@ import java.util.Map;
  */
 public enum GlacierCliCommand {
 
-    INVENTORY("inventory"),
+    // Archive commands
     UPLOAD("upload"),
-    DOWNLOAD("download"),
     DELETE("delete"),
-    LIST("list"),
-    INFO("info"),
+    DOWNLOAD("download"),
+
+    // Vault commands
+    CREATE_VAULT("create-vault"),
     DELETE_VAULT("delete-vault"),
-    CREATE_VAULT("create-vault");
+    INVENTORY("inventory"),
+    INFO("info"),
+    LIST("list");
 
     private static final Map<String, GlacierCliCommand> lookup
             = new HashMap<String, GlacierCliCommand>();


### PR DESCRIPTION
- Add `create-vault` command
- Rename `remove` to `delete-vault` so we only have one verb meaning remove/delete, which is easier to understand.
- Reorganize the Command enum, methods, case statements, and in README.md so they always occur in this order:
  - upload
  - delete
  - download
  - create-vault
  - delete-vault
  - inventory
  - info
  - list
- Clean up the style in README.md (only use `#`s for headers), more spacing between sections
- Clean up Java style to use this style:
  
  ``` java
  private String myFn(String myString, String anotherString) {
      // Some code
  
      return anotherString;
  }
  ```
- Add some comments to indicate what each section of code does
